### PR TITLE
Fix help command on macOS Ventura to use mandoc -a

### DIFF
--- a/encpass.sh
+++ b/encpass.sh
@@ -294,10 +294,10 @@ encpass_remove_man_format() {
 
 encpass_help_prog() {
 	if [ ! -z "$(command -v man)" ]; then
-	  if [ "$(man -l 2>&1 | grep 'invalid' | awk '{print $2}')" = "invalid" ]; then
+	  if [ "$(man -l 2>&1 | grep 'illegal' | awk '{print $2}')" = "illegal" ]; then
 			# man exists, but no -l option is available (e.g macOS)
 			# let's attempt to emulate what man does
-			{ /usr/bin/tbl | /usr/bin/groff -Wall -mtty-char -Tascii -mandoc -c | /usr/bin/less -is; }
+			{ mandoc -a; }
 		else
 			man -l -
 		fi


### PR DESCRIPTION
If interested, I updated encpass_help_prog() to work on macOS Ventura (probably earlier too) with the following:
- "man -l" error output uses "illegal" instead of "invalid"
- to use "mandoc -a" instead of the tbl+groff+less pipeline since macOS doesn't include tbl+groff